### PR TITLE
[FLINK-16504][dynamodb connector] use default dynamodb table config, …

### DIFF
--- a/flink-connectors/flink-connector-dynamodb/src/main/java/org/apache/flink/streaming/connectors/dynamodb/DynamoDbProducerBuilder.java
+++ b/flink-connectors/flink-connector-dynamodb/src/main/java/org/apache/flink/streaming/connectors/dynamodb/DynamoDbProducerBuilder.java
@@ -49,6 +49,7 @@ public class DynamoDbProducerBuilder {
         this.batchSize = DEFAULT_BATCH_SIZE;
         this.queueLimit = DEFAULT_INTERNAL_QUEUE_LIMIT;
         this.retryPolicy = new DefaultBatchWriterRetryPolicy();
+        this.tablesConfig = new DynamoDbTablesConfig();
     }
 
     /**

--- a/flink-connectors/flink-connector-dynamodb/src/main/java/org/apache/flink/streaming/connectors/dynamodb/batch/BatchCollector.java
+++ b/flink-connectors/flink-connector-dynamodb/src/main/java/org/apache/flink/streaming/connectors/dynamodb/batch/BatchCollector.java
@@ -53,8 +53,9 @@ public class BatchCollector {
             int batchSize,
             DynamoDbTablesConfig tableConfig,
             Consumer<ProducerWriteRequest<DynamoDbRequest>> batchConsumer) {
-        this.batchSize = batchSize;
         requireNonNull(batchConsumer);
+        requireNonNull(tableConfig);
+        this.batchSize = batchSize;
         this.batchConsumer = batchConsumer;
         this.tableConfig = tableConfig;
         this.container = new TableRequestsContainer(batchSize);
@@ -62,10 +63,7 @@ public class BatchCollector {
 
     public void accumulateAndPromote(DynamoDbRequest request) {
         String tableName = getTableName(request);
-        DynamoDbTablesConfig.TableConfig tableConfig = null;
-        if (this.tableConfig != null) {
-            tableConfig = this.tableConfig.getTableConfig(tableName);
-        }
+        DynamoDbTablesConfig.TableConfig tableConfig = this.tableConfig.getTableConfig(tableName);
 
         int containerSize =
                 container.addRequest(tableName, PrimaryKey.build(tableConfig, request), request);

--- a/flink-connectors/flink-connector-dynamodb/src/main/java/org/apache/flink/streaming/connectors/dynamodb/retry/DynamoDbExceptionUtils.java
+++ b/flink-connectors/flink-connector-dynamodb/src/main/java/org/apache/flink/streaming/connectors/dynamodb/retry/DynamoDbExceptionUtils.java
@@ -43,7 +43,7 @@ public class DynamoDbExceptionUtils {
         return e instanceof ConditionalCheckFailedException;
     }
 
-    public static boolean isApiCallAttemptTimeoutExcepiton(Exception e) {
+    public static boolean isApiCallAttemptTimeoutException(Exception e) {
         return e instanceof ApiCallAttemptTimeoutException;
     }
 

--- a/flink-end-to-end-tests/flink-connector-dynamodb-end-to-end-tests/pom.xml
+++ b/flink-end-to-end-tests/flink-connector-dynamodb-end-to-end-tests/pom.xml
@@ -73,15 +73,26 @@ under the License.
 		</dependency>
 
 		<dependency>
-			<groupId>junit</groupId>
-			<artifactId>junit</artifactId>
-		</dependency>
-
-		<dependency>
 			<groupId>org.testcontainers</groupId>
 			<artifactId>localstack</artifactId>
 			<version>1.15.1</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-surefire-plugin</artifactId>
+				<executions>
+					<execution>
+						<goals>
+							<goal>test</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
 </project>


### PR DESCRIPTION
…integration tests for failure request handler

<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

*(For example: This pull request makes task deployment go through the blob server, rather than through RPC. That way we avoid re-transferring them on each deployment (during recovery).)*


## Brief change log

*(for example:)*
  - *The TaskInfo is stored in the blob store on job creation time as a persistent artifact*
  - *Deployments RPC transmits only the blob storage reference*
  - *TaskManagers retrieve the TaskInfo from the blob cache*


## Verifying this change

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (100MB)*
  - *Extended integration test for recovery after master (JobManager) failure*
  - *Added test that validates that TaskInfo is transferred only once across recoveries*
  - *Manually verified the change by running a 4 node cluser with 2 JobManagers and 4 TaskManagers, a stateful streaming program, and killing one JobManager and two TaskManagers during the execution, verifying that recovery happens correctly.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / no / don't know)
  - The S3 file system connector: (yes / no / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
